### PR TITLE
Use local IFS for nic info reads

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -184,6 +184,7 @@ display_nics() {
                 break
             fi
         done
+        local IFS=' '
         read -r speed status < <(get_nic_info "${nics[$i]}")
         printf "%d) %s (%s, %s)%s\n" $((i+1)) "${nics[$i]}" "$speed" "$status" "$slave_mark"
     done


### PR DESCRIPTION
## Summary
- maintain the global IFS while parsing `get_nic_info` output
- make `display_nics` use a local space-separated IFS for nic info

## Testing
- `bash -n bond_manager.sh` *(fails: syntax error in existing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e3b3dcdfc8320b013d303e0c2ee97