### PR TITLE
Add cleanup and rollback traps

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -17,6 +17,11 @@ BACKUP_PREFIX="conn-$(date +%Y%m%d_%H%M%S)"
 TIMEOUT=15
 MAX_RETRIES=2
 BOND_MODES=("balance-rr" "active-backup" "balance-xor" "broadcast" "802.3ad" "balance-tlb" "balance-alb")
+TEMP_FILES=()
+
+# Set traps early
+trap cleanup EXIT
+trap rollback ERR
 
 # Ensure script runs as root
 if [[ $EUID -ne 0 ]]; then
@@ -106,6 +111,16 @@ rollback() {
         echo "Error: Rollback failed" >&2
         return 1
     fi
+}
+
+# Remove temporary files and reset state
+cleanup() {
+    set +x
+    for tmp in "${TEMP_FILES[@]}"; do
+        [[ -f "$tmp" ]] && rm -f "$tmp"
+    done
+    stty sane 2>/dev/null
+    tput init 2>/dev/null
 }
 
 # Get available Ethernet NICs


### PR DESCRIPTION
## Summary
- add TEMP_FILES array
- implement `cleanup` function
- trigger cleanup on `EXIT` and rollback on `ERR`

## Testing
- `bash -n bond_manager.sh` *(fails: unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_687e3b421c4c83208e50655b817d7261