### PR TITLE
Fix display_nics showing bond as NIC

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -231,8 +231,9 @@ get_nic_info() {
 
 # Display NICs with indices
 display_nics() {
-    local nics=("$@")
     local bond_name=$1
+    shift
+    local nics=("$@")
     local slaves=()
     if [[ -n "$bond_name" && -f "/proc/net/bonding/$bond_name" ]]; then
         while IFS= read -r line; do


### PR DESCRIPTION
## Summary
- exclude the bond's own name from the NIC list in `display_nics`

## Testing
- `shellcheck bond_manager.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f61357a8c832089d8b8a346ae43b5