### PR TITLE
Fix repair functions removing stale bond profiles

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -896,6 +896,21 @@ repair_bond() {
             fi
         done < "/proc/net/bonding/$bond_name"
     fi
+    # Remove any existing slave connections for the bond to avoid duplicates
+    local current_slaves=($(nmcli -t -f NAME con show | grep "ethernet.*$bond_name"))
+    for conn in "${current_slaves[@]}"; do
+        local del_cmd=("nmcli" "con" "del" "$conn")
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo "${del_cmd[*]}"
+        else
+            if "${del_cmd[@]}" &>>"$LOG_FILE"; then
+                log "Removed stale slave connection $conn from bond $bond_name"
+            else
+                log "Failed to remove stale slave connection $conn from bond $bond_name"
+                echo "Warning: Failed to remove stale slave $conn" >&2
+            fi
+        fi
+    done
     for slave in "${slaves[@]}"; do
         if ! nmcli con show | grep -q "ethernet.*$bond_name.*$slave"; then
             local slave_cmd=("nmcli" "con" "add" "type" "ethernet" "ifname" "$slave" "master" "$bond_name")
@@ -981,6 +996,21 @@ repair_bond_10gb_ab() {
             fi
         done < "/proc/net/bonding/$bond_name"
     fi
+    # Remove any existing slave connections for the bond to avoid duplicates
+    local current_slaves=($(nmcli -t -f NAME con show | grep "ethernet.*$bond_name"))
+    for conn in "${current_slaves[@]}"; do
+        local del_cmd=("nmcli" "con" "del" "$conn")
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo "${del_cmd[*]}"
+        else
+            if "${del_cmd[@]}" &>>"$LOG_FILE"; then
+                log "Removed stale slave connection $conn from bond $bond_name"
+            else
+                log "Failed to remove stale slave connection $conn from bond $bond_name"
+                echo "Warning: Failed to remove stale slave $conn" >&2
+            fi
+        fi
+    done
     for slave in "${slaves[@]}"; do
         if ! ethtool "$slave" 2>/dev/null | grep -q "Speed: 10000Mb/s"; then
             echo "Skipping $slave: not 10Gb" >&2


### PR DESCRIPTION
## Summary
- cleanup stale slave connections before re-adding them

## Testing
- `shellcheck bond_manager.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f66aac8988320a1c3e1263d212203