### PR TITLE
Fix repair functions removing stale bond profiles

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -132,7 +132,10 @@ rollback() {
 remove_slave_connections() {
     local bond=$1
     local slaves=()
-    if ! mapfile -t slaves < <(nmcli -g NAME,connection.master connection show 2>/dev/null | awk -F: -v b="$bond" '$2==b{print $1}') ; then
+    if ! mapfile -t slaves < <(
+            nmcli -t -f NAME,MASTER connection show 2>/dev/null |
+            awk -F: -v b="$bond" '$2==b{print $1}'
+        ); then
         log "Failed to list slave connections for bond $bond"
         slaves=()
     fi


### PR DESCRIPTION
## Summary
- cleanup stale slave connections before re-adding them
- avoid errors when no existing connections are present

## Testing
- `shellcheck bond_manager.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f66aac8988320a1c3e1263d212203