### PR TITLE
Fix get_bond_slaves for older nmcli

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -384,8 +384,12 @@ set_bond_mode() {
 # Return slave connection names for the specified bond
 get_bond_slaves() {
     local bn=$1
-    nmcli -t -f NAME,TYPE,connection.master con show |
-        awk -F: -v bn="$bn" '$2=="ethernet" && $3==bn {print $1}'
+    local conn type master
+    while IFS=: read -r conn type; do
+        [[ $type == "ethernet" ]] || continue
+        master=$(nmcli -t -f connection.master con show "$conn" 2>/dev/null | cut -d: -f2)
+        [[ "$master" == "$bn" ]] && echo "$conn"
+    done < <(nmcli -t -f NAME,TYPE con show)
 }
 
 # Create bond


### PR DESCRIPTION
## Summary
- handle NetworkManager versions without `connection.master` in list output

## Testing
- `bash -n bond_manager.sh`
- `shellcheck bond_manager.sh`

------
https://chatgpt.com/codex/tasks/task_e_688106e0ce948320a882c3eb86a6e2e6