### PR TITLE
Fix NIC discovery output format

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -880,7 +880,9 @@ get_available_nics() {
     fi
     log DEBUG "Discovered NIC candidates: $summary"
 
-    echo "${available[@]}"
+    if (( ${#available[@]} > 0 )); then
+        printf '%s\n' "${available[@]}"
+    fi
 }
 
 # Get NIC speed and status


### PR DESCRIPTION
## Summary
- output newline-delimited device names from get_available_nics so callers see each NIC as a separate entry

## Testing
- Not run (shellcheck not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc1d2750448320bf729d7e815cd123