### PR TITLE
Fix pause prompt requiring double confirmation

### DIFF
--- a/bond_manager.sh
+++ b/bond_manager.sh
@@ -1420,7 +1420,7 @@ prompt_rollback() {
 pause_continue() {
     local prev_timeout=$TIMEOUT
     TIMEOUT=15
-    read_input "Press Enter to continue..." _ || true
+    read_input "Press Enter to continue..." _ true || true
     TIMEOUT=$prev_timeout
 }
 


### PR DESCRIPTION
## Summary
- allow the pause_continue helper to treat empty input as valid so a single Enter dismisses the pause prompt

## Testing
- bash -n bond_manager.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc42af86fc8320832d5eb3449249df